### PR TITLE
기능 1) 채용 공고 등록 기능

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 
 }
 

--- a/src/main/java/com/cheor/wanted_10/base/rsData/RsData.java
+++ b/src/main/java/com/cheor/wanted_10/base/rsData/RsData.java
@@ -1,5 +1,7 @@
 package com.cheor.wanted_10.base.rsData;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
@@ -27,11 +29,11 @@ public class RsData<T> {
 	public static <T> RsData<T> failOf(T data) {
 		return of("F-1", "실패", data);
 	}
-
+	@JsonIgnore
 	public boolean isSuccess() {
 		return resultCode.startsWith("S-");
 	}
-
+	@JsonIgnore
 	public boolean isFail() {
 		return !isSuccess();
 	}

--- a/src/main/java/com/cheor/wanted_10/company/company/CompanyService.java
+++ b/src/main/java/com/cheor/wanted_10/company/company/CompanyService.java
@@ -2,6 +2,22 @@ package com.cheor.wanted_10.company.company;
 
 import org.springframework.stereotype.Service;
 
+import com.cheor.wanted_10.base.rsData.RsData;
+import com.cheor.wanted_10.company.entity.Company;
+import com.cheor.wanted_10.company.repository.CompanyRepository;
+
+import lombok.RequiredArgsConstructor;
+
 @Service
+@RequiredArgsConstructor
 public class CompanyService {
+	private final CompanyRepository companyRepository;
+	public RsData<Company> getCompanyByName(String companyName) {
+		Company findCompany = companyRepository.findByName(companyName);
+		if(findCompany == null) {
+			return RsData.of("F-1", "등록된 회사가 아님");
+		}
+
+		return RsData.of("S-1", "회사 찾기 성공", findCompany);
+	}
 }

--- a/src/main/java/com/cheor/wanted_10/company/repository/CompanyRepository.java
+++ b/src/main/java/com/cheor/wanted_10/company/repository/CompanyRepository.java
@@ -5,4 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.cheor.wanted_10.company.entity.Company;
 
 public interface CompanyRepository extends JpaRepository<Company, Long> {
+	public Company findByName(String companyName);
 }

--- a/src/main/java/com/cheor/wanted_10/recruitment/controller/RecruitmentController.java
+++ b/src/main/java/com/cheor/wanted_10/recruitment/controller/RecruitmentController.java
@@ -1,10 +1,59 @@
 package com.cheor.wanted_10.recruitment.controller;
 
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.cheor.wanted_10.base.rsData.RsData;
+import com.cheor.wanted_10.recruitment.dto.RecruitmentDTO;
+import com.cheor.wanted_10.recruitment.entyty.Recruitment;
+import com.cheor.wanted_10.recruitment.service.RecruitmentService;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @RestController
+@RequestMapping("/recruitment")
 public class RecruitmentController {
+	private final RecruitmentService recruitmentService;
+
+	@AllArgsConstructor
+	@Getter
+	@NoArgsConstructor
+	public static class RecruitmentResponse {
+		private String companyName;
+		private String position;
+		private Integer reward;
+
+		private String content;
+		private String skill;
+		@JsonCreator
+		public RecruitmentResponse(Recruitment recruitment) {
+			this.companyName = recruitment.getCompany().getName();
+			this.position = recruitment.getPosition();
+			this.reward = recruitment.getReward();
+			this.content = recruitment.getContent();
+			this.skill = recruitment.getSkill();
+		}
+	}
+
+	@PostMapping("/register")
+	public RsData<RecruitmentResponse> register(@Valid @RequestBody RecruitmentDTO recruitmentDTO) {
+
+		RsData<Recruitment> rsData = recruitmentService.create(recruitmentDTO);
+		if(rsData.isFail()) {
+			return (RsData)rsData;
+		}
+		return RsData.of(rsData.getResultCode(), rsData.getMsg(), new RecruitmentResponse(rsData.getData()));
+	}
 }

--- a/src/main/java/com/cheor/wanted_10/recruitment/dto/RecruitmentDTO.java
+++ b/src/main/java/com/cheor/wanted_10/recruitment/dto/RecruitmentDTO.java
@@ -1,0 +1,30 @@
+package com.cheor.wanted_10.recruitment.dto;
+
+import com.cheor.wanted_10.recruitment.entyty.Recruitment;
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class RecruitmentDTO {
+	@NotBlank(message = "서비스에 등록된 회사명을 입력해주세요.")
+	private String companyName;
+	@NotBlank(message = "채용포지션을 입력해주세요")
+	private String position;
+
+	@NotNull(message = "채용보상금을 입력해주세요. 없으면 0")
+	private Integer reward;
+
+	@NotBlank(message = "채용내용을 입력헤주세요.")
+	private String content;
+
+	@NotBlank(message = "사용기술을 입력해주세요")
+	private String skill;
+
+}

--- a/src/main/java/com/cheor/wanted_10/recruitment/entyty/Recruitment.java
+++ b/src/main/java/com/cheor/wanted_10/recruitment/entyty/Recruitment.java
@@ -20,6 +20,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.ToString;
 
 @Getter
 @Builder(toBuilder = true)

--- a/src/main/java/com/cheor/wanted_10/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/cheor/wanted_10/recruitment/service/RecruitmentService.java
@@ -1,4 +1,44 @@
 package com.cheor.wanted_10.recruitment.service;
 
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.cheor.wanted_10.base.rsData.RsData;
+import com.cheor.wanted_10.company.company.CompanyService;
+import com.cheor.wanted_10.company.entity.Company;
+import com.cheor.wanted_10.recruitment.controller.RecruitmentController;
+import com.cheor.wanted_10.recruitment.dto.RecruitmentDTO;
+import com.cheor.wanted_10.recruitment.entyty.Recruitment;
+import com.cheor.wanted_10.recruitment.repository.RecruitmentRepository;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class RecruitmentService {
+	private final CompanyService companyService;
+	private final RecruitmentRepository recruitmentRepository;
+
+	@Transactional
+	public RsData<Recruitment> create(RecruitmentDTO recruitmentDTO) {
+		String companyName = recruitmentDTO.getCompanyName();
+		RsData<Company> company = companyService.getCompanyByName(companyName);
+		if(company.isFail()) {
+			return RsData.of("F-1", "본 서비스에 등록된 회사가 아닙니다.");
+		}
+		Recruitment recruitment = Recruitment.builder()
+			.content(recruitmentDTO.getContent())
+			.skill(recruitmentDTO.getSkill())
+			.company(company.getData())
+			.reward(recruitmentDTO.getReward())
+			.position(recruitmentDTO.getPosition())
+			.build();
+
+		recruitmentRepository.save(recruitment);
+
+		return RsData.of("S-1", "지원공고가 성공적으로 등록되었습니다.", recruitment);
+	}
 }

--- a/src/test/java/com/cheor/wanted_10/Wanted10ApplicationTests.java
+++ b/src/test/java/com/cheor/wanted_10/Wanted10ApplicationTests.java
@@ -2,8 +2,11 @@ package com.cheor.wanted_10;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Profile;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class Wanted10ApplicationTests {
 
 	@Test

--- a/src/test/java/com/cheor/wanted_10/recruitment/controller/RecruitmentControllerTest.java
+++ b/src/test/java/com/cheor/wanted_10/recruitment/controller/RecruitmentControllerTest.java
@@ -21,6 +21,7 @@ import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.cheor.wanted_10.recruitment.entyty.Recruitment;
+import com.cheor.wanted_10.recruitment.service.RecruitmentService;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -31,6 +32,9 @@ public class RecruitmentControllerTest {
 	@Autowired
 	private MockMvc mvc;
 
+	@Autowired
+	private RecruitmentService recruitmentService;
+
 	@Test
 	@DisplayName("채용공고 등록 테스트")
 	void t001() throws Exception {
@@ -39,11 +43,11 @@ public class RecruitmentControllerTest {
 				post("/recruitment/register")
 					.content("""
 						{
-							"companyId": 1,
+							"companyName": "회사1",
 						   "position": "백엔드 주니어 개발자",
 						   "reward": 1000000,
 						   "content": "원티드랩에서 백엔드 주니어 개발자를 채용합니다. 자격요건은..",
-						   "skill":" Python"
+						   "skill":"Python"
 						}
 						""")
 					.contentType(new MediaType(MediaType.APPLICATION_JSON, StandardCharsets.UTF_8))
@@ -52,6 +56,7 @@ public class RecruitmentControllerTest {
 
 		resultActions
 			.andExpect(status().is2xxSuccessful())
-			.andExpect(handler().methodName("register"));
+			.andExpect(handler().methodName("register"))
+			.andExpect(jsonPath("$.resultCode").value("S-1"));
 	}
 }


### PR DESCRIPTION
필수 구현기능 중 첫번째, 채용 공고 등록 기능을 구현했습니다.
- 입력값
{
    "companyName": "회사1",
    "position": "백엔드 주니어 개발자",
    "reward": 1000000,
    "content": "원티드랩에서 백엔드 주니어 개발자를 채용합니다. 자격요건은..",
    "skill":"Python"
}
- 사용자에게 회사의 Id를 받기에는 사용자가 모를 것 같고, 로그인 기능이 없어 회사명을 입력 받는것이 나을 것 같다 판단하였습니다.
- 로그인 기능이 있다면, 로그인된 사용자 정보에 소속된 회사 정보를 가져오면 입력받지 않아도 API 구현이 가능합니다. 하지만 과제 로그인 기능을 구현하지 않아 회사명을 입력받도록 하였고, 등록된 회사가 아니라면 등록 불가능 하도록 구현하였습니다.

** src/main/java/com/cheor/wanted_10/base/rsData/RsData.java **
- [x] 결과 코드, 메세지, 데이터를 담고있는 응답용 객체입니다. Jackson 라이브러리에 의해 자동으로 Json화 될 때 is~ 시작하는 것들도 포함되기에 Json화 할 때 Ignore 되도록 하였습니다.

** src/main/java/com/cheor/wanted_10/company/company/CompanyService.java **
- [x] 회사 정보 찾기를 성공했을 때의 메세지와 데이터를 담아 리턴합니다.

**src/main/java/com/cheor/wanted_10/recruitment/service/RecruitmentService.java**
- [x] 입력받은 회사명이 본 서비스에 등록되어 있는지 검사하고 등록된 회사라면 채용 공고를 등록합니다.
- [x] 등록된 회사가 아니라면 실패 코드를 리턴합니다.

**src/test/java/com/cheor/wanted_10/recruitment/controller/RecruitmentControllerTest.java**
- [x] Post 요청을 보냈을 때 응답 결과 중 결과 코드가 S-로 시작하는지 확인하여 성공 여부를 테스트합니다.