### PR TITLE
기능 2) 채용 공고 수정 기능

### DIFF
--- a/src/main/java/com/cheor/wanted_10/base/initData/NotProd.java
+++ b/src/main/java/com/cheor/wanted_10/base/initData/NotProd.java
@@ -11,6 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.cheor.wanted_10.apply.repository.ApplyRepository;
 import com.cheor.wanted_10.company.entity.Company;
 import com.cheor.wanted_10.company.repository.CompanyRepository;
+import com.cheor.wanted_10.recruitment.entyty.Recruitment;
 import com.cheor.wanted_10.recruitment.repository.RecruitmentRepository;
 import com.cheor.wanted_10.user.entity.SiteUser;
 import com.cheor.wanted_10.user.repository.UserRepository;
@@ -54,6 +55,23 @@ public class NotProd {
 
 				userRepository.saveAll(List.of(user1, user2));
 
+				Recruitment recruitment1 = Recruitment.builder()
+					.content("테스트 채용1")
+					.skill("python")
+					.reward(3000)
+					.company(company1)
+					.position("백엔드")
+					.build();
+
+				Recruitment recruitment2 = Recruitment.builder()
+					.content("테스트 채용2")
+					.skill("java")
+					.reward(1000)
+					.company(company2)
+					.position("백엔드")
+					.build();
+
+				recruitmentRepository.saveAll(List.of(recruitment1, recruitment2));
 			}
 		};
 	}

--- a/src/main/java/com/cheor/wanted_10/recruitment/controller/RecruitmentController.java
+++ b/src/main/java/com/cheor/wanted_10/recruitment/controller/RecruitmentController.java
@@ -1,5 +1,9 @@
 package com.cheor.wanted_10.recruitment.controller;
 
+import static org.springframework.http.MediaType.*;
+
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -7,6 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.cheor.wanted_10.base.rsData.RsData;
 import com.cheor.wanted_10.recruitment.dto.RecruitmentDTO;
+import com.cheor.wanted_10.recruitment.dto.RecruitmentModifyDTO;
 import com.cheor.wanted_10.recruitment.entyty.Recruitment;
 import com.cheor.wanted_10.recruitment.service.RecruitmentService;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -55,5 +60,33 @@ public class RecruitmentController {
 			return (RsData)rsData;
 		}
 		return RsData.of(rsData.getResultCode(), rsData.getMsg(), new RecruitmentResponse(rsData.getData()));
+	}
+
+	@AllArgsConstructor
+	@Getter
+	@NoArgsConstructor
+	public static class ModifyResponse {
+		private String companyName;
+		private String position;
+		private Integer reward;
+		private String content;
+		private String skill;
+		@JsonCreator
+		public ModifyResponse(Recruitment recruitment) {
+			this.companyName = recruitment.getCompany().getName();
+			this.position = recruitment.getPosition();
+			this.reward = recruitment.getReward();
+			this.content = recruitment.getContent();
+			this.skill = recruitment.getSkill();
+		}
+	}
+
+	@PatchMapping(value = "/modify/{id}", consumes = APPLICATION_JSON_VALUE)
+	public RsData<ModifyResponse> modify(@PathVariable Long id, @RequestBody RecruitmentModifyDTO recruitmentModifyDTO) {
+		RsData<Recruitment> rsData = recruitmentService.modify(id, recruitmentModifyDTO);
+		if(rsData.isFail()) {
+			return (RsData)rsData;
+		}
+		return RsData.of(rsData.getResultCode(), rsData.getMsg(), new ModifyResponse(rsData.getData()));
 	}
 }

--- a/src/main/java/com/cheor/wanted_10/recruitment/dto/RecruitmentModifyDTO.java
+++ b/src/main/java/com/cheor/wanted_10/recruitment/dto/RecruitmentModifyDTO.java
@@ -1,0 +1,15 @@
+package com.cheor.wanted_10.recruitment.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class RecruitmentModifyDTO {
+	private String position;
+	private Integer reward;
+	private String content;
+	private String skill;
+}

--- a/src/main/java/com/cheor/wanted_10/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/cheor/wanted_10/recruitment/service/RecruitmentService.java
@@ -1,5 +1,7 @@
 package com.cheor.wanted_10.recruitment.service;
 
+import java.util.Optional;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -8,6 +10,7 @@ import com.cheor.wanted_10.company.company.CompanyService;
 import com.cheor.wanted_10.company.entity.Company;
 import com.cheor.wanted_10.recruitment.controller.RecruitmentController;
 import com.cheor.wanted_10.recruitment.dto.RecruitmentDTO;
+import com.cheor.wanted_10.recruitment.dto.RecruitmentModifyDTO;
 import com.cheor.wanted_10.recruitment.entyty.Recruitment;
 import com.cheor.wanted_10.recruitment.repository.RecruitmentRepository;
 
@@ -40,5 +43,27 @@ public class RecruitmentService {
 		recruitmentRepository.save(recruitment);
 
 		return RsData.of("S-1", "지원공고가 성공적으로 등록되었습니다.", recruitment);
+	}
+
+	@Transactional
+	public RsData<Recruitment> modify(Long recruitmentId, RecruitmentModifyDTO recruitmentModifyDTO) {
+		Optional<Recruitment> opRecruitment = recruitmentRepository.findById(recruitmentId);
+
+		if(opRecruitment.isEmpty()) {
+			return RsData.of("F-1", "등록되지 않은 공고입니다.");
+		}
+
+		Recruitment recruitment = opRecruitment.get();
+
+		Recruitment modifyRecruitment = recruitment.toBuilder()
+			.position(recruitmentModifyDTO.getPosition() == null ? recruitment.getPosition() : recruitmentModifyDTO.getPosition())
+			.content(recruitmentModifyDTO.getContent() == null ? recruitment.getContent() : recruitmentModifyDTO.getContent())
+			.reward(recruitmentModifyDTO.getReward() == null ? recruitment.getReward() : recruitmentModifyDTO.getReward())
+			.skill(recruitmentModifyDTO.getSkill() == null ? recruitment.getSkill() : recruitmentModifyDTO.getSkill())
+			.build();
+
+		recruitmentRepository.save(modifyRecruitment);
+
+		return RsData.of("S-1", "공고가 수정되었습니다.", modifyRecruitment);
 	}
 }

--- a/src/test/java/com/cheor/wanted_10/recruitment/controller/RecruitmentControllerTest.java
+++ b/src/test/java/com/cheor/wanted_10/recruitment/controller/RecruitmentControllerTest.java
@@ -57,6 +57,51 @@ public class RecruitmentControllerTest {
 		resultActions
 			.andExpect(status().is2xxSuccessful())
 			.andExpect(handler().methodName("register"))
-			.andExpect(jsonPath("$.resultCode").value("S-1"));
+			.andExpect(jsonPath("$.resultCode").value("S-1"))
+			.andExpect(jsonPath("$.data.skill").value("Python"));
+	}
+
+	@Test
+	@DisplayName("채용공고 수정 테스트1")
+	void t002() throws Exception {
+		ResultActions resultActions = mvc
+			.perform(
+				patch("/recruitment/modify/1")
+					.content("""
+						{
+						   "position": "수정된개발자공고!"
+						}
+						""")
+					.contentType(new MediaType(MediaType.APPLICATION_JSON, StandardCharsets.UTF_8))
+			)
+			.andDo(print());
+
+		resultActions
+			.andExpect(status().is2xxSuccessful())
+			.andExpect(handler().methodName("modify"))
+			.andExpect(jsonPath("$.resultCode").value("S-1"))
+			.andExpect(jsonPath("$.data.position").value("수정된개발자공고!"));
+	}
+
+	@Test
+	@DisplayName("채용공고 수정 테스트2")
+	void t003() throws Exception {
+		ResultActions resultActions = mvc
+			.perform(
+				patch("/recruitment/modify/1")
+					.content("""
+						{
+						   "skill": "수정된skill!"
+						}
+						""")
+					.contentType(new MediaType(MediaType.APPLICATION_JSON, StandardCharsets.UTF_8))
+			)
+			.andDo(print());
+
+		resultActions
+			.andExpect(status().is2xxSuccessful())
+			.andExpect(handler().methodName("modify"))
+			.andExpect(jsonPath("$.resultCode").value("S-1"))
+			.andExpect(jsonPath("$.data.skill").value("수정된skill!"));
 	}
 }


### PR DESCRIPTION
필수 구현기능 중 두번째, 채용 공고 수 기능을 구현했습니다.

입력값
{
	"position": "수정된개발자공고!"
}
- URL을 통해 채용공고의 Id를 받아 조회하고, 해당 내용을 수정합니다.
- 일부 속성만 넘겨도 수정 가능하도록 하였고, 회사명이나 회사Id는 DTO객체에 받지 않기에 무시됩니다.
- 실제 서비스하는 API라면, DTO객체에 포함한 다음에 만일 값이 넘어오면 **회사 정보는 수정 불가능합니다** 정도의 메세지를 사용자에게 띄워줘도 좋지 않을까 싶습니다.
- 로그인 하여 등록자거나 관리자거나 확인할 수 있지만 인증/인가는 미션에서 생략이기에 구현하지 않았습니다.

** src/main/java/com/cheor/wanted_10/base/initData/NotProd.java **
- 초기 데이터 2건 추가 하였습니다.(채용 공고)

** src/main/java/com/cheor/wanted_10/recruitment/controller/RecruitmentController.java **
- 채용 공고의 Id는 Url로 받고, 나머지 정보는 JSON으로 받아서 객체화 합니다
- 이후 서비스로 토스하고, 결과를 rsData 형태로 리턴합니다.

** src/main/java/com/cheor/wanted_10/recruitment/service/RecruitmentService.java**
- 등록된 공고가 없다면 존재하지 않는 공고로, 실패 코드와 함께 RsData 객체를 반환합니다.
- PATCH 메서드로 일부 속성만 수정할 수 있으므로 null이 아닌 경우(사용자가 수정 데이터 첨부)엔 기존값을 넣도록 toBuilder로 구현하였습니다.

** src/test/java/com/cheor/wanted_10/recruitment/controller/RecruitmentControllerTest.java **
- 이전에 구현한 등록 테스트 케이스 데이터 검증을 추가했습니다.
- 수정 테스트 케이스를 추가하였습니다.