### PR TITLE
기능 3) 채용 공고 삭제 기능

### DIFF
--- a/src/main/java/com/cheor/wanted_10/recruitment/controller/RecruitmentController.java
+++ b/src/main/java/com/cheor/wanted_10/recruitment/controller/RecruitmentController.java
@@ -2,6 +2,7 @@ package com.cheor.wanted_10.recruitment.controller;
 
 import static org.springframework.http.MediaType.*;
 
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -88,5 +89,11 @@ public class RecruitmentController {
 			return (RsData)rsData;
 		}
 		return RsData.of(rsData.getResultCode(), rsData.getMsg(), new ModifyResponse(rsData.getData()));
+	}
+
+	@DeleteMapping("/{id}")
+	public RsData delete(@PathVariable Long id) {
+		RsData rsData = recruitmentService.delete(id);
+		return rsData;
 	}
 }

--- a/src/main/java/com/cheor/wanted_10/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/cheor/wanted_10/recruitment/service/RecruitmentService.java
@@ -66,4 +66,19 @@ public class RecruitmentService {
 
 		return RsData.of("S-1", "공고가 수정되었습니다.", modifyRecruitment);
 	}
+
+	@Transactional
+	public RsData delete(Long id) {
+		Optional<Recruitment> opRecruitment = recruitmentRepository.findById(id);
+
+		if(opRecruitment.isEmpty()) {
+			return RsData.of("F-1", "존재하지 않는 공고입니다.");
+		}
+
+		Recruitment recruitment = opRecruitment.get();
+
+		recruitmentRepository.delete(recruitment);
+
+		return RsData.of("S-1", "%s 회사의 %s 직무 공고가 성공적으로 삭제되었습니다.".formatted(recruitment.getCompany().getName(), recruitment.getPosition()));
+	}
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,8 @@
 spring:
+  mvc:
+    hiddenmethod:
+      filter:
+        enabled: true
   profiles:
     active: dev
   datasource:

--- a/src/test/java/com/cheor/wanted_10/recruitment/controller/RecruitmentControllerTest.java
+++ b/src/test/java/com/cheor/wanted_10/recruitment/controller/RecruitmentControllerTest.java
@@ -104,4 +104,33 @@ public class RecruitmentControllerTest {
 			.andExpect(jsonPath("$.resultCode").value("S-1"))
 			.andExpect(jsonPath("$.data.skill").value("수정된skill!"));
 	}
+
+	@Test
+	@DisplayName("채용공고 삭제 테스트 및 삭제한거 다시 삭제 시도")
+	void t004() throws Exception {
+		ResultActions resultActions = mvc
+			.perform(
+				delete("/recruitment/1")
+			)
+			.andDo(print());
+
+		resultActions
+			.andExpect(status().is2xxSuccessful())
+			.andExpect(handler().methodName("delete"))
+			.andExpect(jsonPath("$.resultCode").value("S-1"))
+			.andExpect(jsonPath("$.msg").value("회사1 회사의 백엔드 직무 공고가 성공적으로 삭제되었습니다."));
+
+		// 삭제한거 다시 삭제하려 시도
+		resultActions = mvc
+			.perform(
+				delete("/recruitment/1")
+			)
+			.andDo(print());
+
+		resultActions
+			.andExpect(status().is2xxSuccessful())
+			.andExpect(handler().methodName("delete"))
+			.andExpect(jsonPath("$.resultCode").value("F-1"))
+			.andExpect(jsonPath("$.msg").value("존재하지 않는 공고입니다."));
+	}
 }


### PR DESCRIPTION
**src/main/resources/application.yml**
- 프론트 부분을 구현하지 않았지만, form태그의 경우 GET, POST만 지원하기에 해당 속성을 켜줘서 DELETE, PUT, PATCH를 form을 통해 받을 수 있도록 켰습니다.
- Ajax 등 활용하여 통신할 때는 필요하지 않지만, 확장성을 고려하여 속성을 켰습니다.

**src/main/java/com/cheor/wanted_10/recruitment/controller/RecruitmentController.java**
- DELETE 메서드 요청 URL을 통해 삭제할 채용공고의 Id를 받아와서 처리합니다.
- 공고 작성자 등을 인증해야 하지만, 인증 절차를 구현하지 않았기에 실제 데이터 삭제만 구현하였습니다