### PR TITLE
기능 4) 채용 공고 전체 조회 & 단건 조회

### DIFF
--- a/src/main/java/com/cheor/wanted_10/company/entity/Company.java
+++ b/src/main/java/com/cheor/wanted_10/company/entity/Company.java
@@ -45,7 +45,4 @@ public class Company {
 	private String nation;
 
 	private String region;
-	@OneToMany(mappedBy = "company", cascade = {CascadeType.REMOVE})
-	@ToString.Exclude
-	private List<Recruitment> recruitmentList = new ArrayList<>();
 }

--- a/src/main/java/com/cheor/wanted_10/recruitment/controller/RecruitmentController.java
+++ b/src/main/java/com/cheor/wanted_10/recruitment/controller/RecruitmentController.java
@@ -2,7 +2,11 @@ package com.cheor.wanted_10.recruitment.controller;
 
 import static org.springframework.http.MediaType.*;
 
+import java.util.List;
+import java.util.Optional;
+
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -43,6 +47,7 @@ public class RecruitmentController {
 
 		private String content;
 		private String skill;
+
 		@JsonCreator
 		public RecruitmentResponse(Recruitment recruitment) {
 			this.companyName = recruitment.getCompany().getName();
@@ -57,7 +62,7 @@ public class RecruitmentController {
 	public RsData<RecruitmentResponse> register(@Valid @RequestBody RecruitmentDTO recruitmentDTO) {
 
 		RsData<Recruitment> rsData = recruitmentService.create(recruitmentDTO);
-		if(rsData.isFail()) {
+		if (rsData.isFail()) {
 			return (RsData)rsData;
 		}
 		return RsData.of(rsData.getResultCode(), rsData.getMsg(), new RecruitmentResponse(rsData.getData()));
@@ -72,6 +77,7 @@ public class RecruitmentController {
 		private Integer reward;
 		private String content;
 		private String skill;
+
 		@JsonCreator
 		public ModifyResponse(Recruitment recruitment) {
 			this.companyName = recruitment.getCompany().getName();
@@ -83,9 +89,10 @@ public class RecruitmentController {
 	}
 
 	@PatchMapping(value = "/modify/{id}", consumes = APPLICATION_JSON_VALUE)
-	public RsData<ModifyResponse> modify(@PathVariable Long id, @RequestBody RecruitmentModifyDTO recruitmentModifyDTO) {
+	public RsData<ModifyResponse> modify(@PathVariable Long id,
+		@RequestBody RecruitmentModifyDTO recruitmentModifyDTO) {
 		RsData<Recruitment> rsData = recruitmentService.modify(id, recruitmentModifyDTO);
-		if(rsData.isFail()) {
+		if (rsData.isFail()) {
 			return (RsData)rsData;
 		}
 		return RsData.of(rsData.getResultCode(), rsData.getMsg(), new ModifyResponse(rsData.getData()));
@@ -95,5 +102,22 @@ public class RecruitmentController {
 	public RsData delete(@PathVariable Long id) {
 		RsData rsData = recruitmentService.delete(id);
 		return rsData;
+	}
+
+	@AllArgsConstructor
+	@Getter
+	public static class RecruitmentsResponse {
+		private final List<Recruitment> recruitments;
+	}
+
+	@GetMapping("/list")
+	public RsData<RecruitmentsResponse> readAll() {
+		List<Recruitment> recruitments = recruitmentService.getAll();
+
+		return RsData.of(
+			"S-1",
+			"공고 조회",
+			new RecruitmentsResponse(recruitments)
+		);
 	}
 }

--- a/src/main/java/com/cheor/wanted_10/recruitment/controller/RecruitmentController.java
+++ b/src/main/java/com/cheor/wanted_10/recruitment/controller/RecruitmentController.java
@@ -88,7 +88,7 @@ public class RecruitmentController {
 		}
 	}
 
-	@PatchMapping(value = "/modify/{id}", consumes = APPLICATION_JSON_VALUE)
+	@PatchMapping(value = "/modify/{id}")
 	public RsData<ModifyResponse> modify(@PathVariable Long id,
 		@RequestBody RecruitmentModifyDTO recruitmentModifyDTO) {
 		RsData<Recruitment> rsData = recruitmentService.modify(id, recruitmentModifyDTO);
@@ -119,5 +119,14 @@ public class RecruitmentController {
 			"공고 조회",
 			new RecruitmentsResponse(recruitments)
 		);
+	}
+
+	@GetMapping("/{id}")
+	public RsData<RecruitmentResponse> read(@PathVariable Long id) {
+		RsData<Recruitment> rsData = recruitmentService.get(id);
+		if (rsData.isFail()) {
+			return (RsData)rsData;
+		}
+		return RsData.of(rsData.getResultCode(), rsData.getMsg(), new RecruitmentResponse(rsData.getData()));
 	}
 }

--- a/src/main/java/com/cheor/wanted_10/recruitment/repository/RecruitmentRepository.java
+++ b/src/main/java/com/cheor/wanted_10/recruitment/repository/RecruitmentRepository.java
@@ -1,8 +1,11 @@
 package com.cheor.wanted_10.recruitment.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.cheor.wanted_10.recruitment.entyty.Recruitment;
 
 public interface RecruitmentRepository extends JpaRepository<Recruitment, Long> {
+	List<Recruitment> findAllByOrderByIdDesc();
 }

--- a/src/main/java/com/cheor/wanted_10/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/cheor/wanted_10/recruitment/service/RecruitmentService.java
@@ -86,4 +86,14 @@ public class RecruitmentService {
 	public List<Recruitment> getAll() {
 		return recruitmentRepository.findAllByOrderByIdDesc();
 	}
+
+	public RsData<Recruitment> get(Long id) {
+		Optional<Recruitment> opRecruitment = recruitmentRepository.findById(id);
+
+		if(opRecruitment.isEmpty()) {
+			return RsData.of("F-1", "존재하지 않는 공고입니다.");
+		}
+
+		return RsData.of("S-1", "조회 성공", opRecruitment.get());
+	}
 }

--- a/src/main/java/com/cheor/wanted_10/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/cheor/wanted_10/recruitment/service/RecruitmentService.java
@@ -1,5 +1,6 @@
 package com.cheor.wanted_10.recruitment.service;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.stereotype.Service;
@@ -80,5 +81,9 @@ public class RecruitmentService {
 		recruitmentRepository.delete(recruitment);
 
 		return RsData.of("S-1", "%s 회사의 %s 직무 공고가 성공적으로 삭제되었습니다.".formatted(recruitment.getCompany().getName(), recruitment.getPosition()));
+	}
+
+	public List<Recruitment> getAll() {
+		return recruitmentRepository.findAllByOrderByIdDesc();
 	}
 }

--- a/src/test/java/com/cheor/wanted_10/recruitment/controller/RecruitmentControllerTest.java
+++ b/src/test/java/com/cheor/wanted_10/recruitment/controller/RecruitmentControllerTest.java
@@ -149,4 +149,20 @@ public class RecruitmentControllerTest {
 			.andExpect(jsonPath("$.resultCode").value("S-1"))
 			.andExpect(jsonPath("$.data.recruitments[0].company.name").value("회사2"));
 	}
+
+	@Test
+	@DisplayName("채용공고 단건 조회")
+	void t006() throws Exception {
+		ResultActions resultActions = mvc
+			.perform(
+				get("/recruitment/1")
+			)
+			.andDo(print());
+
+		resultActions
+			.andExpect(status().is2xxSuccessful())
+			.andExpect(handler().methodName("read"))
+			.andExpect(jsonPath("$.resultCode").value("S-1"))
+			.andExpect(jsonPath("$.data.companyName").value("회사1"));
+	}
 }

--- a/src/test/java/com/cheor/wanted_10/recruitment/controller/RecruitmentControllerTest.java
+++ b/src/test/java/com/cheor/wanted_10/recruitment/controller/RecruitmentControllerTest.java
@@ -133,4 +133,20 @@ public class RecruitmentControllerTest {
 			.andExpect(jsonPath("$.resultCode").value("F-1"))
 			.andExpect(jsonPath("$.msg").value("존재하지 않는 공고입니다."));
 	}
+
+	@Test
+	@DisplayName("채용공고 목록 조회")
+	void t005() throws Exception {
+		ResultActions resultActions = mvc
+			.perform(
+				get("/recruitment/list")
+			)
+			.andDo(print());
+
+		resultActions
+			.andExpect(status().is2xxSuccessful())
+			.andExpect(handler().methodName("readAll"))
+			.andExpect(jsonPath("$.resultCode").value("S-1"))
+			.andExpect(jsonPath("$.data.recruitments[0].company.name").value("회사2"));
+	}
 }


### PR DESCRIPTION
채용 공고 전체 조회 및 단건 조회 기능을 구현하였습니다.
- 공고 전체 조회 : 최신순 조회
- 공고 단건 조회 : URL을 통해 id를 받아서 단건을 조회

**src/main/java/com/cheor/wanted_10/company/entity/Company.java**
- Recrument에서 Company와 ManyToOne으로 연관관계를 매핑했기에, Company에서는 지움으로 써 Json화 될 때 문제 없도록 수정하였습니다.
- Company에서 Recrument를 참조하여 어떤 기능을 하고 있지 않아 삭제하였습니다. 