### PR TITLE
추가 기능 1) 공고 지원 기능

### DIFF
--- a/src/main/java/com/cheor/wanted_10/apply/controller/ApplyController.java
+++ b/src/main/java/com/cheor/wanted_10/apply/controller/ApplyController.java
@@ -1,12 +1,46 @@
 package com.cheor.wanted_10.apply.controller;
 
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.cheor.wanted_10.apply.dto.ApplyDTO;
+import com.cheor.wanted_10.apply.entity.Apply;
 import com.cheor.wanted_10.apply.service.ApplyService;
+import com.cheor.wanted_10.base.rsData.RsData;
+import com.cheor.wanted_10.recruitment.controller.RecruitmentController;
+import com.cheor.wanted_10.recruitment.dto.RecruitmentDTO;
+import com.cheor.wanted_10.recruitment.entyty.Recruitment;
+import com.cheor.wanted_10.recruitment.service.RecruitmentService;
+import com.fasterxml.jackson.annotation.JsonCreator;
 
+import jakarta.validation.Valid;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @RestController
+@RequestMapping("/recruitment/apply")
 public class ApplyController {
+	private final ApplyService applyService;
+
+	@AllArgsConstructor
+	@Getter
+	@NoArgsConstructor
+	public static class ApplyResponse {
+		private Apply apply;
+	}
+	@PostMapping("")
+	public RsData<ApplyResponse> create(@Valid @RequestBody ApplyDTO applyDTO) {
+
+		RsData<Apply> rsData = applyService.create(applyDTO);
+		if (rsData.isFail()) {
+			return (RsData)rsData;
+		}
+		return RsData.of(rsData.getResultCode(), rsData.getMsg(), new ApplyResponse(rsData.getData()));
+	}
+
 }

--- a/src/main/java/com/cheor/wanted_10/apply/dto/ApplyDTO.java
+++ b/src/main/java/com/cheor/wanted_10/apply/dto/ApplyDTO.java
@@ -1,0 +1,18 @@
+package com.cheor.wanted_10.apply.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class ApplyDTO {
+	@NotNull(message = "등록된 채용공고의 id를 입력해주세요")
+	private Long recruitmentId;
+
+	@NotNull(message = "사용자 id를 입력해주세요")
+	private Long siteUserId;
+}

--- a/src/main/java/com/cheor/wanted_10/apply/repository/ApplyRepository.java
+++ b/src/main/java/com/cheor/wanted_10/apply/repository/ApplyRepository.java
@@ -5,4 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.cheor.wanted_10.apply.entity.Apply;
 
 public interface ApplyRepository extends JpaRepository<Apply, Long> {
+	Apply findBySiteUserIdAndRecruitmentId(Long userId, Long recruitmentId);
 }

--- a/src/main/java/com/cheor/wanted_10/apply/service/ApplyService.java
+++ b/src/main/java/com/cheor/wanted_10/apply/service/ApplyService.java
@@ -1,7 +1,67 @@
 package com.cheor.wanted_10.apply.service;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.cheor.wanted_10.apply.controller.ApplyController;
+import com.cheor.wanted_10.apply.dto.ApplyDTO;
+import com.cheor.wanted_10.apply.entity.Apply;
+import com.cheor.wanted_10.apply.repository.ApplyRepository;
+import com.cheor.wanted_10.base.rsData.RsData;
+import com.cheor.wanted_10.company.entity.Company;
+import com.cheor.wanted_10.recruitment.entyty.Recruitment;
+import com.cheor.wanted_10.recruitment.service.RecruitmentService;
+import com.cheor.wanted_10.user.entity.SiteUser;
+import com.cheor.wanted_10.user.service.UserService;
+
+import lombok.RequiredArgsConstructor;
 
 @Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class ApplyService {
+	private final RecruitmentService recruitmentService;
+	private final UserService userService;
+	private final ApplyRepository applyRepository;
+	@Transactional
+	public RsData<Apply> create(ApplyDTO applyDTO) {
+		// 공고 존재하는지 확인
+		RsData<Recruitment> recruitmentRsData = recruitmentService.get(applyDTO.getRecruitmentId());
+		if(recruitmentRsData.isFail()) {
+			return RsData.of("F-1", "존재하지 않는 공고입니다.");
+		}
+		// 사용자 존재하는지 확인
+		RsData<SiteUser> siteUserRsData = userService.get(applyDTO.getSiteUserId());
+		if(siteUserRsData.isFail()) {
+			return RsData.of("F-1", "존재하지 않는 사용자입니다.");
+		}
+		// 이전에 지원했었는지 확인
+		if(havingApplyHistory(applyDTO.getRecruitmentId(), applyDTO.getSiteUserId())){
+			return RsData.of("F-1", "이미 지원하였습니다.");
+		}
+		// 누가, 어떤회사의, 어떤 공고에 지원했다는 정보를 Apply에 저장하기 위한 정보 추출
+		Recruitment recruitment = recruitmentService.get(applyDTO.getRecruitmentId()).getData();
+		Company company = recruitment.getCompany();
+		SiteUser user = userService.get(applyDTO.getSiteUserId()).getData();
+
+		Apply history = Apply.builder()
+			.company(company)
+			.siteUser(user)
+			.recruitment(recruitment)
+			.build();
+
+		applyRepository.save(history);
+
+		return RsData.of("S-1", "성공적으로 지원하였습니다.", history);
+
+	}
+
+	private boolean havingApplyHistory(Long recruitmentId, Long siteUserId) {
+		Apply applyHistory = applyRepository.findBySiteUserIdAndRecruitmentId(siteUserId, recruitmentId);
+
+		if(applyHistory ==null) {
+			return false;
+		}
+		return true;
+	}
 }

--- a/src/main/java/com/cheor/wanted_10/user/service/UserService.java
+++ b/src/main/java/com/cheor/wanted_10/user/service/UserService.java
@@ -1,4 +1,26 @@
 package com.cheor.wanted_10.user.service;
 
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.cheor.wanted_10.base.rsData.RsData;
+import com.cheor.wanted_10.user.entity.SiteUser;
+import com.cheor.wanted_10.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class UserService {
+	private final UserRepository userRepository;
+	public RsData<SiteUser> get(Long siteUserId) {
+		Optional<SiteUser> opSiteUser = userRepository.findById(siteUserId);
+		if(opSiteUser.isEmpty()) {
+			return RsData.of("F-1", "존재하지 않는 사용자 입니다.");
+		}
+		return RsData.of("S-1", "사용자 조회 성공", opSiteUser.get());
+	}
 }

--- a/src/test/java/com/cheor/wanted_10/apply/controller/ApplyControllerTest.java
+++ b/src/test/java/com/cheor/wanted_10/apply/controller/ApplyControllerTest.java
@@ -46,9 +46,10 @@ public class ApplyControllerTest {
 
 		resultActions
 			.andExpect(status().is2xxSuccessful())
-			.andExpect(handler().methodName("register"))
+			.andExpect(handler().methodName("create"))
 			.andExpect(jsonPath("$.resultCode").value("S-1"))
-			.andExpect(jsonPath("$.msg").value("지원을 완료하였습니다."));
+			.andExpect(jsonPath("$.msg").value("성공적으로 지원하였습니다."))
+			.andExpect(jsonPath(("$.data.apply.id")).value(1));
 
 		resultActions = mvc
 			.perform(
@@ -65,8 +66,8 @@ public class ApplyControllerTest {
 
 		resultActions
 			.andExpect(status().is2xxSuccessful())
-			.andExpect(handler().methodName("register"))
+			.andExpect(handler().methodName("create"))
 			.andExpect(jsonPath("$.resultCode").value("F-1"))
-			.andExpect(jsonPath("$.msg").value("이미 지원한 내역이 있어 지원할 수 없습니다."));
+			.andExpect(jsonPath("$.msg").value("이미 지원하였습니다."));
 	}
 }

--- a/src/test/java/com/cheor/wanted_10/apply/controller/ApplyControllerTest.java
+++ b/src/test/java/com/cheor/wanted_10/apply/controller/ApplyControllerTest.java
@@ -1,0 +1,72 @@
+package com.cheor.wanted_10.apply.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@ActiveProfiles("test")
+@TestMethodOrder(MethodOrderer.MethodName.class)
+public class ApplyControllerTest {
+	@Autowired
+	private MockMvc mvc;
+
+	@Test
+	@DisplayName("채용공고 지원 테스트")
+	void t001() throws Exception {
+		ResultActions resultActions = mvc
+			.perform(
+				post("/recruitment/apply")
+					.content("""
+						{
+							"recruitmentId": 1,
+							"siteUserId": 1
+						}
+						""")
+					.contentType(new MediaType(MediaType.APPLICATION_JSON, StandardCharsets.UTF_8))
+			)
+			.andDo(print());
+
+		resultActions
+			.andExpect(status().is2xxSuccessful())
+			.andExpect(handler().methodName("register"))
+			.andExpect(jsonPath("$.resultCode").value("S-1"))
+			.andExpect(jsonPath("$.msg").value("지원을 완료하였습니다."));
+
+		resultActions = mvc
+			.perform(
+				post("/recruitment/apply")
+					.content("""
+						{
+							"recruitmentId": 1,
+							"siteUserId": 1
+						}
+						""")
+					.contentType(new MediaType(MediaType.APPLICATION_JSON, StandardCharsets.UTF_8))
+			)
+			.andDo(print());
+
+		resultActions
+			.andExpect(status().is2xxSuccessful())
+			.andExpect(handler().methodName("register"))
+			.andExpect(jsonPath("$.resultCode").value("F-1"))
+			.andExpect(jsonPath("$.msg").value("이미 지원한 내역이 있어 지원할 수 없습니다."));
+	}
+}


### PR DESCRIPTION
선택 기능 첫 번째로, 채용공고 지원 기능을 구현하였습니다. 
전송 데이터
{
  "recruitmentId": 1,
  "siteUserId": 1
}

채용 공고 id와 사용자 id를 이용해 유효성 검사를 진행한 뒤 지원 내역에 저장합니다.
만일 지원 내역이 있을 경우 등록이 안되도록 구현하였습니다.(DB에서 공고 & 사용자 id가 일치하는 데이터 있는지 확인)

**src/main/java/com/cheor/wanted_10/apply/service/ApplyService.java**
- 공고 존재 여부 확인
- 사용자 존재 여부 확인
- 이전에 지원한 내역 있는지 확인 : havingApplyHistory 메서드, 참이면 지원 불가

