### PR TITLE
추가 기능 2) 공고 상세 페이지 내 동일 회사 다른 공고 id 출력 기능

### DIFF
--- a/src/main/java/com/cheor/wanted_10/base/initData/NotProd.java
+++ b/src/main/java/com/cheor/wanted_10/base/initData/NotProd.java
@@ -71,7 +71,23 @@ public class NotProd {
 					.position("백엔드")
 					.build();
 
-				recruitmentRepository.saveAll(List.of(recruitment1, recruitment2));
+				Recruitment recruitment3 = Recruitment.builder()
+					.content("테스트 채용3")
+					.skill("python123")
+					.reward(3230)
+					.company(company1)
+					.position("백엔드123")
+					.build();
+
+				Recruitment recruitment4 = Recruitment.builder()
+					.content("테스트 채용4")
+					.skill("python123")
+					.reward(3800)
+					.company(company1)
+					.position("백엔드123")
+					.build();
+
+				recruitmentRepository.saveAll(List.of(recruitment1, recruitment2, recruitment3, recruitment4));
 			}
 		};
 	}

--- a/src/main/java/com/cheor/wanted_10/recruitment/entyty/Recruitment.java
+++ b/src/main/java/com/cheor/wanted_10/recruitment/entyty/Recruitment.java
@@ -1,6 +1,8 @@
 package com.cheor.wanted_10.recruitment.entyty;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
@@ -8,6 +10,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import com.cheor.wanted_10.company.entity.Company;
 
+import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;

--- a/src/main/java/com/cheor/wanted_10/recruitment/repository/RecruitmentRepository.java
+++ b/src/main/java/com/cheor/wanted_10/recruitment/repository/RecruitmentRepository.java
@@ -4,8 +4,11 @@ import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import com.cheor.wanted_10.company.entity.Company;
 import com.cheor.wanted_10.recruitment.entyty.Recruitment;
 
 public interface RecruitmentRepository extends JpaRepository<Recruitment, Long> {
 	List<Recruitment> findAllByOrderByIdDesc();
+
+	List<Recruitment> findAllByCompany(Company company);
 }

--- a/src/main/java/com/cheor/wanted_10/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/cheor/wanted_10/recruitment/service/RecruitmentService.java
@@ -9,14 +9,11 @@ import org.springframework.transaction.annotation.Transactional;
 import com.cheor.wanted_10.base.rsData.RsData;
 import com.cheor.wanted_10.company.company.CompanyService;
 import com.cheor.wanted_10.company.entity.Company;
-import com.cheor.wanted_10.recruitment.controller.RecruitmentController;
 import com.cheor.wanted_10.recruitment.dto.RecruitmentDTO;
 import com.cheor.wanted_10.recruitment.dto.RecruitmentModifyDTO;
 import com.cheor.wanted_10.recruitment.entyty.Recruitment;
 import com.cheor.wanted_10.recruitment.repository.RecruitmentRepository;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -30,7 +27,7 @@ public class RecruitmentService {
 	public RsData<Recruitment> create(RecruitmentDTO recruitmentDTO) {
 		String companyName = recruitmentDTO.getCompanyName();
 		RsData<Company> company = companyService.getCompanyByName(companyName);
-		if(company.isFail()) {
+		if (company.isFail()) {
 			return RsData.of("F-1", "본 서비스에 등록된 회사가 아닙니다.");
 		}
 		Recruitment recruitment = Recruitment.builder()
@@ -50,16 +47,19 @@ public class RecruitmentService {
 	public RsData<Recruitment> modify(Long recruitmentId, RecruitmentModifyDTO recruitmentModifyDTO) {
 		Optional<Recruitment> opRecruitment = recruitmentRepository.findById(recruitmentId);
 
-		if(opRecruitment.isEmpty()) {
+		if (opRecruitment.isEmpty()) {
 			return RsData.of("F-1", "등록되지 않은 공고입니다.");
 		}
 
 		Recruitment recruitment = opRecruitment.get();
 
 		Recruitment modifyRecruitment = recruitment.toBuilder()
-			.position(recruitmentModifyDTO.getPosition() == null ? recruitment.getPosition() : recruitmentModifyDTO.getPosition())
-			.content(recruitmentModifyDTO.getContent() == null ? recruitment.getContent() : recruitmentModifyDTO.getContent())
-			.reward(recruitmentModifyDTO.getReward() == null ? recruitment.getReward() : recruitmentModifyDTO.getReward())
+			.position(recruitmentModifyDTO.getPosition() == null ? recruitment.getPosition() :
+				recruitmentModifyDTO.getPosition())
+			.content(recruitmentModifyDTO.getContent() == null ? recruitment.getContent() :
+				recruitmentModifyDTO.getContent())
+			.reward(
+				recruitmentModifyDTO.getReward() == null ? recruitment.getReward() : recruitmentModifyDTO.getReward())
 			.skill(recruitmentModifyDTO.getSkill() == null ? recruitment.getSkill() : recruitmentModifyDTO.getSkill())
 			.build();
 
@@ -72,7 +72,7 @@ public class RecruitmentService {
 	public RsData delete(Long id) {
 		Optional<Recruitment> opRecruitment = recruitmentRepository.findById(id);
 
-		if(opRecruitment.isEmpty()) {
+		if (opRecruitment.isEmpty()) {
 			return RsData.of("F-1", "존재하지 않는 공고입니다.");
 		}
 
@@ -80,7 +80,8 @@ public class RecruitmentService {
 
 		recruitmentRepository.delete(recruitment);
 
-		return RsData.of("S-1", "%s 회사의 %s 직무 공고가 성공적으로 삭제되었습니다.".formatted(recruitment.getCompany().getName(), recruitment.getPosition()));
+		return RsData.of("S-1",
+			"%s 회사의 %s 직무 공고가 성공적으로 삭제되었습니다.".formatted(recruitment.getCompany().getName(), recruitment.getPosition()));
 	}
 
 	public List<Recruitment> getAll() {
@@ -90,16 +91,11 @@ public class RecruitmentService {
 	public RsData<Recruitment> get(Long id) {
 		Optional<Recruitment> opRecruitment = recruitmentRepository.findById(id);
 
-		if(opRecruitment.isEmpty()) {
+		if (opRecruitment.isEmpty()) {
 			return RsData.of("F-1", "존재하지 않는 공고입니다.");
 		}
 
-		Recruitment recruitment = opRecruitment.get();
-
-		List<Recruitment> allRecruitmentByCompany = recruitmentRepository.findAllByCompany(recruitment.getCompany());
-
 		return RsData.of("S-1", "조회 성공", opRecruitment.get());
-
 	}
 
 	public List<Recruitment> getCompanyRecruitments(Company company) {

--- a/src/main/java/com/cheor/wanted_10/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/cheor/wanted_10/recruitment/service/RecruitmentService.java
@@ -94,6 +94,15 @@ public class RecruitmentService {
 			return RsData.of("F-1", "존재하지 않는 공고입니다.");
 		}
 
+		Recruitment recruitment = opRecruitment.get();
+
+		List<Recruitment> allRecruitmentByCompany = recruitmentRepository.findAllByCompany(recruitment.getCompany());
+
 		return RsData.of("S-1", "조회 성공", opRecruitment.get());
+
+	}
+
+	public List<Recruitment> getCompanyRecruitments(Company company) {
+		return recruitmentRepository.findAllByCompany(company);
 	}
 }

--- a/src/test/java/com/cheor/wanted_10/recruitment/controller/RecruitmentControllerTest.java
+++ b/src/test/java/com/cheor/wanted_10/recruitment/controller/RecruitmentControllerTest.java
@@ -167,4 +167,21 @@ public class RecruitmentControllerTest {
 			.andExpect(jsonPath("$.data.otherRecruitmentsId[0]").value(3))
 			.andExpect(jsonPath("$.data.otherRecruitmentsId[1]").value(4));
 	}
+
+	@Test
+	@DisplayName("채용공고 단건 조회, 회사 내 공고가 1개일 때 다른 공고 id 출력 안되는지 테스트")
+	void t007() throws Exception {
+		ResultActions resultActions = mvc
+			.perform(
+				get("/recruitment/2")
+			)
+			.andDo(print());
+
+		resultActions
+			.andExpect(status().is2xxSuccessful())
+			.andExpect(handler().methodName("read"))
+			.andExpect(jsonPath("$.resultCode").value("S-1"))
+			.andExpect(jsonPath("$.data.companyName").value("회사2"))
+			.andExpect(jsonPath("$.data.otherRecruitmentsId").isEmpty());
+	}
 }

--- a/src/test/java/com/cheor/wanted_10/recruitment/controller/RecruitmentControllerTest.java
+++ b/src/test/java/com/cheor/wanted_10/recruitment/controller/RecruitmentControllerTest.java
@@ -147,7 +147,7 @@ public class RecruitmentControllerTest {
 			.andExpect(status().is2xxSuccessful())
 			.andExpect(handler().methodName("readAll"))
 			.andExpect(jsonPath("$.resultCode").value("S-1"))
-			.andExpect(jsonPath("$.data.recruitments[0].company.name").value("회사2"));
+			.andExpect(jsonPath("$.data.recruitments[0].company.name").value("회사1"));
 	}
 
 	@Test
@@ -163,6 +163,8 @@ public class RecruitmentControllerTest {
 			.andExpect(status().is2xxSuccessful())
 			.andExpect(handler().methodName("read"))
 			.andExpect(jsonPath("$.resultCode").value("S-1"))
-			.andExpect(jsonPath("$.data.companyName").value("회사1"));
+			.andExpect(jsonPath("$.data.companyName").value("회사1"))
+			.andExpect(jsonPath("$.data.otherRecruitmentsId[0]").value(3))
+			.andExpect(jsonPath("$.data.otherRecruitmentsId[1]").value(4));
 	}
 }


### PR DESCRIPTION
**src/main/java/com/cheor/wanted_10/base/initData/NotProd.java**
- 테스트 데이터 2건을 추가하여 공고 상세 정보 요청 시 다른 id가 출력되는지 테스트 하고자 추가하였습니다.

** src/main/java/com/cheor/wanted_10/recruitment/controller/RecruitmentController.java **
- 가져온 공고에서 Company 객체를 추출해서 다른 공고가 있다면 다른 공고 리스트의 id를 반환 DTO 객체에 넣고, 없다면 빈 리스트를 객체에 넣습니다.

** src/test/java/com/cheor/wanted_10/recruitment/controller/RecruitmentControllerTest.java **
- 테스트 케이스를 추가하였습니다. 다른 공고가 있는 경우와 없는 경우 모두 추가하였습니다.

