### PR TITLE
Swagger 도입하여 API 문서화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,9 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+    // 스프링독 추가(스웨거 사용 위함)
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/cheor/wanted_10/apply/controller/ApplyController.java
+++ b/src/main/java/com/cheor/wanted_10/apply/controller/ApplyController.java
@@ -15,6 +15,8 @@ import com.cheor.wanted_10.recruitment.entyty.Recruitment;
 import com.cheor.wanted_10.recruitment.service.RecruitmentService;
 import com.fasterxml.jackson.annotation.JsonCreator;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -24,6 +26,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/recruitment/apply")
+@Tag(name = "ApplyController", description = "사용자 채용 공고 지원")
 public class ApplyController {
 	private final ApplyService applyService;
 
@@ -34,6 +37,7 @@ public class ApplyController {
 		private Apply apply;
 	}
 	@PostMapping("")
+	@Operation(summary = "사용자 채용 공고 지원 기능")
 	public RsData<ApplyResponse> create(@Valid @RequestBody ApplyDTO applyDTO) {
 
 		RsData<Apply> rsData = applyService.create(applyDTO);

--- a/src/main/java/com/cheor/wanted_10/base/exceptionHandler/ApiGlobalExceptionHandler.java
+++ b/src/main/java/com/cheor/wanted_10/base/exceptionHandler/ApiGlobalExceptionHandler.java
@@ -1,0 +1,46 @@
+package com.cheor.wanted_10.base.exceptionHandler;
+
+import static org.springframework.http.HttpStatus.*;
+
+import java.util.stream.Collectors;
+import org.springframework.context.support.DefaultMessageSourceResolvable;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import com.cheor.wanted_10.base.rsData.RsData;
+
+@RestControllerAdvice(annotations = {RestController.class}) // 모든 @RestController 에서 발생한 예외에 대한 제어권을 가로챈다.
+public class ApiGlobalExceptionHandler {
+	@ExceptionHandler(MethodArgumentNotValidException.class)
+	@ResponseStatus(NOT_FOUND)
+	public RsData<String> errorHandler(MethodArgumentNotValidException exception) {
+		String msg = exception
+			.getBindingResult()
+			.getAllErrors()
+			.stream()
+			.map(DefaultMessageSourceResolvable::getDefaultMessage)
+			.collect(Collectors.joining("/"));
+
+		String data = exception
+			.getBindingResult()
+			.getAllErrors()
+			.stream()
+			.map(DefaultMessageSourceResolvable::getCode)
+			.collect(Collectors.joining("/"));
+
+		return RsData.of("F-MethodArgumentNotValidException", msg, data);
+	}
+
+	@ExceptionHandler(RuntimeException.class)
+	@ResponseStatus(INTERNAL_SERVER_ERROR)
+	public RsData<String> errorHandler(RuntimeException exception) {
+		String msg = exception.getClass().toString();
+
+		String data = exception.getMessage();
+
+		return RsData.of("F-RuntimeException", msg, data);
+	}
+}

--- a/src/main/java/com/cheor/wanted_10/base/springDoc/SpringDocConfig.java
+++ b/src/main/java/com/cheor/wanted_10/base/springDoc/SpringDocConfig.java
@@ -1,0 +1,11 @@
+package com.cheor.wanted_10.base.springDoc;
+
+import org.springframework.context.annotation.Configuration;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+
+@Configuration
+@OpenAPIDefinition(info = @Info(title = "Wanted Pre ", version = "v1"))
+public class SpringDocConfig {
+}

--- a/src/main/java/com/cheor/wanted_10/recruitment/controller/RecruitmentController.java
+++ b/src/main/java/com/cheor/wanted_10/recruitment/controller/RecruitmentController.java
@@ -20,6 +20,8 @@ import com.cheor.wanted_10.recruitment.entyty.Recruitment;
 import com.cheor.wanted_10.recruitment.service.RecruitmentService;
 import com.fasterxml.jackson.annotation.JsonCreator;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -29,6 +31,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/recruitment")
+@Tag(name = "RecruitmentController", description = "채용 공고 CRUD")
 public class RecruitmentController {
 	private final RecruitmentService recruitmentService;
 
@@ -56,6 +59,7 @@ public class RecruitmentController {
 	}
 
 	@PostMapping("/register")
+	@Operation(summary = "채용 공고 등록")
 	public RsData<RecruitmentResponse> register(@Valid @RequestBody RecruitmentDTO recruitmentDTO) {
 
 		RsData<Recruitment> rsData = recruitmentService.create(recruitmentDTO);
@@ -88,6 +92,7 @@ public class RecruitmentController {
 	}
 
 	@PatchMapping(value = "/modify/{id}")
+	@Operation(summary = "채용 공고 수정")
 	public RsData<ModifyResponse> modify(@PathVariable Long id,
 		@RequestBody RecruitmentModifyDTO recruitmentModifyDTO) {
 		RsData<Recruitment> rsData = recruitmentService.modify(id, recruitmentModifyDTO);
@@ -98,6 +103,7 @@ public class RecruitmentController {
 	}
 
 	@DeleteMapping("/{id}")
+	@Operation(summary = "채용 공고 삭제")
 	public RsData delete(@PathVariable Long id) {
 		RsData rsData = recruitmentService.delete(id);
 		return rsData;
@@ -110,6 +116,7 @@ public class RecruitmentController {
 	}
 
 	@GetMapping("/list")
+	@Operation(summary = "채용 공고 전체 조회 혹은 검색")
 	public RsData<RecruitmentsResponse> readAll(@RequestParam(required = false) String search) {
 		List<Recruitment> recruitments;
 
@@ -144,6 +151,7 @@ public class RecruitmentController {
 	}
 
 	@GetMapping("/{id}")
+	@Operation(summary = "채용 공고 상세 조회")
 	public RsData<RecruitmentDetailResponse> read(@PathVariable Long id) {
 		RsData<Recruitment> rsData = recruitmentService.get(id);
 		if (rsData.isFail()) {


### PR DESCRIPTION
Spring Doc 의존성을 추가하여 Swagger를 도입하였습니다. 각 메서드들을 문서화 하여 보기 좋게 되었습니다.

pull 이후 주소 : http://localhost:8080/swagger-ui/index.html?continue#/

**src/main/java/com/cheor/wanted_10/base/exceptionHandler/ApiGlobalExceptionHandler.java**
- 위 파일은 스프링에서 기본적으로 나오는 Json 오류 양식을 RsData 양식으로 깔끔하게 나오도록 했습니다.
- 주로 Valid 어노테이션에 의해 조건이 안맞을 때 나오던 양식이 RsData 양식과 맞지 않아 커스터마이징 해줍니다.